### PR TITLE
Set a symmetric padding for input component

### DIFF
--- a/src/components/input.css
+++ b/src/components/input.css
@@ -1,6 +1,7 @@
 .Input {
     height: var(--spacing-4);
     padding-left: var(--spacing-1);
+    padding-right: var(--spacing-1);
     font-size: var(--fs-3);
     border-radius: var(--br-m);
     border: none;


### PR DESCRIPTION
## Before (without symmetric padding)
| First example |  Second example |
| ------------- | ------------- |
| <img width="387" alt="capture d ecran 2017-05-25 a 13 58 33" src="https://cloud.githubusercontent.com/assets/11244106/26450805/85af2d38-4159-11e7-9923-025ee7733e3d.png"> | <img width="378" alt="capture d ecran 2017-05-25 a 14 13 36" src="https://cloud.githubusercontent.com/assets/11244106/26450810/8bbad696-4159-11e7-8f29-a466ba2a4cb1.png"> |

## After (with symmetric padding)
| First example |  Second example |
| ------------- | ------------- |
| <img width="361" alt="capture d ecran 2017-05-25 a 14 55 11" src="https://cloud.githubusercontent.com/assets/11244106/26451032/8e4292ea-415a-11e7-9b72-0119ad4402c9.png"> | <img width="378" alt="capture d ecran 2017-05-25 a 14 13 43" src="https://cloud.githubusercontent.com/assets/11244106/26450822/9527b1f4-4159-11e7-9002-9f31f04d91a3.png"> |




